### PR TITLE
Adds missing token for `onTokenGenerated` callback

### DIFF
--- a/src/js/components/recaptchaV3.js
+++ b/src/js/components/recaptchaV3.js
@@ -68,7 +68,7 @@ export default class RecaptchaV3 {
     injectTokenToForm() {
         try {
             grecaptcha.execute(this.siteKey, {action: this.action})
-                .then(() => this.onTokenGenerated());
+                .then((token) => this.onTokenGenerated(token));
         } catch (error) {
             this.form.dispatchEvent(new CustomEvent('formbuilder.fatal-captcha'));
         }


### PR DESCRIPTION
Adds the token from the Google API response to the `onTokenGenerated` callback, so it can be assigned to the hidden field.