### PR TITLE
Fixes shared options

### DIFF
--- a/src/js/core/fetchManager.js
+++ b/src/js/core/fetchManager.js
@@ -8,7 +8,7 @@ export default class FetchManager {
 
     constructor(form, options = {}, endpoints = null) {
         this.form = form;
-        this.options = Object.assign(FETCH_MANAGER_DEFAULTS, options);
+        this.options = Object.assign({}, FETCH_MANAGER_DEFAULTS, options);
         this.elementTransformer = new ElementTransformer(this.form, TYPE_VALIDATION, this.options.elementTransformer);
 
         this.endpoints = endpoints;


### PR DESCRIPTION
Fixes an issue, where the FetchManager options have been shared between instances.

`Object.assign(target, ...sources)` does not create a new instance, but extends the `target` object. See: https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Object/assign

This bug resulted in manipulation of the wrong form instance in some cases (e.g. inside `onGeneralError`).